### PR TITLE
used current aiogram for html escaping

### DIFF
--- a/tracker/telegram/bot.py
+++ b/tracker/telegram/bot.py
@@ -8,10 +8,9 @@ from aiogram.client.default import DefaultBotProperties
 from aiogram.filters import CommandObject, CommandStart
 from aiogram.types.message import Message
 from aiogram.utils.deep_linking import create_start_link
+from aiogram.utils.formatting import Text
 from aiogram.utils.keyboard import ReplyKeyboardBuilder, ReplyKeyboardMarkup
 from dotenv import load_dotenv
-from aiogram.utils.formatting import Text
-
 from tracker import ISSUES_URL, PULLS_URL, get_issues_without_pull_requests
 from tracker.utils import (
     create_telegram_user,
@@ -182,7 +181,8 @@ async def send_revision_messages(telegram_id: str, reviews_data: list[dict]) -> 
             "-------------------------------"
             f"Repo: <b>{data['repo']}</b>"
             "\n"
-            f"Pull Request: <b>{data['pull']}/</b>" "\n"
+            f"Pull Request: <b>{data['pull']}/</b>"
+            "\n"
             f"<b>Reviews:</b>"
             "\n"
         )

--- a/tracker/telegram/bot.py
+++ b/tracker/telegram/bot.py
@@ -120,7 +120,7 @@ def escape_html(text: str) -> str:
     :return: A string with HTML symbols escaped, replacing '&' with '&amp;', '<' with '&lt;',
              and '>' with '&gt;'.
     """
-    return html.unparse()
+    return html.unparse(text)
 
 
 @dp.message(F.text == "📖get available issues📖")

--- a/tracker/telegram/bot.py
+++ b/tracker/telegram/bot.py
@@ -10,6 +10,7 @@ from aiogram.types.message import Message
 from aiogram.utils.deep_linking import create_start_link
 from aiogram.utils.keyboard import ReplyKeyboardBuilder, ReplyKeyboardMarkup
 from dotenv import load_dotenv
+from aiogram.utils.formatting import Text
 
 from tracker import ISSUES_URL, PULLS_URL, get_issues_without_pull_requests
 from tracker.utils import (
@@ -118,10 +119,9 @@ def escape_html(text: str) -> str:
     Escapes HTML symbols in the text to ensure proper rendering in Telegram messages.
 
     :param text: The input string that may contain HTML symbols.
-    :return: A string with HTML symbols escaped, replacing '&' with '&amp;', '<' with '&lt;',
-             and '>' with '&gt;'.
+    :return: A string with HTML symbols escaped using the Text class.
     """
-    return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    return Text(text).as_html()
 
 
 @dp.message(F.text == "📖get available issues📖")

--- a/tracker/telegram/bot.py
+++ b/tracker/telegram/bot.py
@@ -3,12 +3,11 @@ import logging
 import os
 import sys
 
-from aiogram import Bot, Dispatcher, F
+from aiogram import Bot, Dispatcher, F, html
 from aiogram.client.default import DefaultBotProperties
 from aiogram.filters import CommandObject, CommandStart
 from aiogram.types.message import Message
 from aiogram.utils.deep_linking import create_start_link
-from aiogram.utils.formatting import Text
 from aiogram.utils.keyboard import ReplyKeyboardBuilder, ReplyKeyboardMarkup
 from dotenv import load_dotenv
 from tracker import ISSUES_URL, PULLS_URL, get_issues_without_pull_requests
@@ -118,9 +117,10 @@ def escape_html(text: str) -> str:
     Escapes HTML symbols in the text to ensure proper rendering in Telegram messages.
 
     :param text: The input string that may contain HTML symbols.
-    :return: A string with HTML symbols escaped using the Text class.
+    :return: A string with HTML symbols escaped, replacing '&' with '&amp;', '<' with '&lt;',
+             and '>' with '&gt;'.
     """
-    return Text(text).as_html()
+    return html.unparse()
 
 
 @dp.message(F.text == "📖get available issues📖")


### PR DESCRIPTION
Resolves issue #30 

Utilized the as_html method of the `Text` class to escape HTML symbols properly

![Screenshot 2024-11-23 235441](https://github.com/user-attachments/assets/93611226-754f-4c51-8936-ad82efbe3bc3)
