### PR TITLE
feat: Create project role choices

### DIFF
--- a/tracker/choices.py
+++ b/tracker/choices.py
@@ -1,0 +1,16 @@
+from django.db import models
+
+
+class Roles(models.TextChoices):
+    """
+    The roles class adds a role to members on a project.
+
+    The choices include project lead and contributors.
+
+    Attributes:
+        project_lead (Role Enumeration): Project Lead Enumeration Variant.
+        contributor (Role Enumertion): Contributor Enumeration Variant.
+    """
+
+    PROJECT_LEAD = "lead", "Tech-lead"
+    CONTRIBUTOR = "contributor", "Contributor"


### PR DESCRIPTION
closes #35 

This pull request provides Role choices for projects, the choices include
- Project Lead
- Contributor

The `Roles` class inherits the `models.TextChoices` class in django.